### PR TITLE
Default value for horta logs synced folder.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Configure the horta log directory so it will read MUC logs from
   # there:
-  config.vm.synced_folder ENV['HORTA_LOGS'], "/horta_logs"
+  config.vm.synced_folder ENV['HORTA_LOGS'] || "", "/horta_logs"
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]


### PR DESCRIPTION
If the `HORTA_LOGS` environment variable is not defined Vagrant shows this:

```
Bringing machine 'default' up with 'virtualbox' provider...
/usr/share/vagrant/plugins/kernel_v2/config/vm.rb:418:in `initialize': can't convert nil into String (TypeError)
    from /usr/share/vagrant/plugins/kernel_v2/config/vm.rb:418:in `new'
    from /usr/share/vagrant/plugins/kernel_v2/config/vm.rb:418:in `block in validate'
    from /usr/share/vagrant/plugins/kernel_v2/config/vm.rb:413:in `each'
    from /usr/share/vagrant/plugins/kernel_v2/config/vm.rb:413:in `validate'
    from /usr/lib/ruby/vendor_ruby/vagrant/config/v2/root.rb:67:in `block in validate'
    from /usr/lib/ruby/vendor_ruby/vagrant/config/v2/root.rb:63:in `each'
    from /usr/lib/ruby/vendor_ruby/vagrant/config/v2/root.rb:63:in `validate'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/builtin/config_validate.rb:15:in `call'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/warden.rb:34:in `call'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/builtin/call.rb:57:in `call'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/warden.rb:34:in `call'
    from /usr/share/vagrant/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/warden.rb:34:in `call'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/builder.rb:116:in `call'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/runner.rb:69:in `block in run'
    from /usr/lib/ruby/vendor_ruby/vagrant/util/busy.rb:19:in `busy'
    from /usr/lib/ruby/vendor_ruby/vagrant/action/runner.rb:69:in `run'
    from /usr/lib/ruby/vendor_ruby/vagrant/machine.rb:147:in `action'
    from /usr/lib/ruby/vendor_ruby/vagrant/batch_action.rb:63:in `block (2 levels) in run'
```

I think there should be an option to configure it later and start the vm anyway.
